### PR TITLE
arrange afterSeconds

### DIFF
--- a/FacTest/M5_I2C_BM8563.cpp
+++ b/FacTest/M5_I2C_BM8563.cpp
@@ -303,7 +303,7 @@ int I2C_BM8563::WakeChecksum(int afterSeconds) {
     get_value_0f_h = ReadReg(0x0F);
     while ((get_value_0e_h != rtc_reg_value_0e_h) ||
            (get_value_0f_h != rtc_reg_value_0f_h)) {
-        SetAlarmIRQ(afterSeconds);
+        SetAlarmIRQ(afterSeconds * div);
         get_value_0e_h = ReadReg(0x0E);
         get_value_0f_h = ReadReg(0x0F);
     }

--- a/FacTest/M5_I2C_BM8563.cpp
+++ b/FacTest/M5_I2C_BM8563.cpp
@@ -262,6 +262,10 @@ void I2C_BM8563::WakeAfterSeconds(int afterSeconds) {
     while (ReadReg(0x00) != 0) {
         WriteReg(0x00, 0);
     }
+    if (afterSeconds >= 255) {
+        int div = 60;
+        afterSeconds = (afterSeconds / div) * div;
+    }
     SetAlarmIRQ(afterSeconds);
     WakeChecksum(afterSeconds);
     while (ReadReg(0x01) != 0x01) {


### PR DESCRIPTION
SetAlarmIRQ and WakeChecksum don't match the register value in some cases if afterSeconds is greater than 255. 
Then it can't loop out in WakeChecksum.